### PR TITLE
PYMT-667: Added missing getter in ActivityInterface

### DIFF
--- a/src/Bridge/Doctrine/Entities/Activity.php
+++ b/src/Bridge/Doctrine/Entities/Activity.php
@@ -3,11 +3,10 @@ declare(strict_types=1);
 
 namespace EoneoPay\Webhooks\Bridge\Doctrine\Entities;
 
-use DateTime as BaseDateTime;
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use EoneoPay\Externals\ORM\Entity;
 use EoneoPay\Externals\ORM\Interfaces\EntityInterface;
-use EoneoPay\Utils\DateTime;
 use EoneoPay\Utils\Interfaces\UtcDateTimeInterface;
 use EoneoPay\Webhooks\Bridge\Doctrine\Entities\Schemas\ActivitySchema;
 use EoneoPay\Webhooks\Model\ActivityInterface;
@@ -53,12 +52,10 @@ final class Activity extends Entity implements ActivityInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
      */
     public function getOccurredAt(): ?DateTime
     {
-        return $this->occurredAt === null ? null : new DateTime($this->occurredAt);
+        return $this->occurredAt;
     }
 
     /**
@@ -96,7 +93,7 @@ final class Activity extends Entity implements ActivityInterface
     /**
      * {@inheritdoc}
      */
-    public function setOccurredAt(BaseDateTime $occurredAt): void
+    public function setOccurredAt(DateTime $occurredAt): void
     {
         $this->occurredAt = $occurredAt;
     }

--- a/src/Model/ActivityInterface.php
+++ b/src/Model/ActivityInterface.php
@@ -3,9 +3,8 @@ declare(strict_types=1);
 
 namespace EoneoPay\Webhooks\Model;
 
-use DateTime as BaseDateTime;
+use DateTime;
 use EoneoPay\Externals\ORM\Interfaces\EntityInterface;
-use EoneoPay\Utils\DateTime;
 
 interface ActivityInterface
 {
@@ -33,7 +32,7 @@ interface ActivityInterface
     /**
      * Returns occurred at date for the activity
      *
-     * @return \EoneoPay\Utils\DateTime|null
+     * @return \DateTime|null
      */
     public function getOccurredAt(): ?DateTime;
 
@@ -67,7 +66,7 @@ interface ActivityInterface
      *
      * @return void
      */
-    public function setOccurredAt(BaseDateTime $occurredAt): void;
+    public function setOccurredAt(DateTime $occurredAt): void;
 
     /**
      * Sets the activity payload.

--- a/tests/Stubs/Bridge/Doctrine/Entity/ActivityStub.php
+++ b/tests/Stubs/Bridge/Doctrine/Entity/ActivityStub.php
@@ -3,8 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\EoneoPay\Webhooks\Stubs\Bridge\Doctrine\Entity;
 
-use DateTime as BaseDateTime;
-use EoneoPay\Utils\DateTime;
+use DateTime;
 use EoneoPay\Webhooks\Bridge\Doctrine\Entities\Schemas\ActivitySchema;
 use EoneoPay\Webhooks\Model\ActivityInterface;
 use Tests\EoneoPay\Webhooks\Stubs\Externals\EntityStub;
@@ -51,12 +50,10 @@ class ActivityStub implements ActivityInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @throws \EoneoPay\Utils\Exceptions\InvalidDateTimeStringException
      */
     public function getOccurredAt(): ?DateTime
     {
-        return $this->occurredAt === null ? null : new DateTime($this->occurredAt);
+        return $this->occurredAt;
     }
 
     /**
@@ -94,7 +91,7 @@ class ActivityStub implements ActivityInterface
     /**
      * {@inheritdoc}
      */
-    public function setOccurredAt(BaseDateTime $occurredAt): void
+    public function setOccurredAt(DateTime $occurredAt): void
     {
         $this->data['occurredAt'] = $occurredAt;
     }

--- a/tests/Unit/Bridge/Doctrine/Entities/ActivityTest.php
+++ b/tests/Unit/Bridge/Doctrine/Entities/ActivityTest.php
@@ -53,7 +53,6 @@ class ActivityTest extends BaseEntityTestCase
         static::assertSame(['payload'], $activity->getPayload());
         static::assertSame(EntityStub::class, $activity->getPrimaryClass());
         static::assertSame('55', $activity->getPrimaryId());
-        static::assertInstanceOf(DateTime::class, $activity->getOccurredAt());
         static::assertEquals(new DateTime('2100-01-01T10:11:12Z'), $activity->getOccurredAt());
     }
 }


### PR DESCRIPTION
This PR is to add `getOccurredAt()` in `ActivityInterface`.