### PR TITLE
PYMT-1006: Added WebhookResponseInterface methods

### DIFF
--- a/src/Bridge/Doctrine/Entities/WebhookResponse.php
+++ b/src/Bridge/Doctrine/Entities/WebhookResponse.php
@@ -73,6 +73,14 @@ class WebhookResponse extends Entity implements WebhookResponseInterface
     /**
      * {@inheritdoc}
      */
+    public function getResponse(): ?string
+    {
+        return $this->response;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getResponseId(): string
     {
         return $this->responseId;
@@ -163,6 +171,7 @@ class WebhookResponse extends Entity implements WebhookResponseInterface
             'error_reason' => $this->getErrorReason(),
             'id' => $this->getResponseId(),
             'request' => $this->request->toArray(),
+            'response' => $this->getResponse(),
             'status_code' => $this->getStatusCode(),
             'successful' => $this->isSuccessful()
         ];

--- a/src/Model/WebhookResponseInterface.php
+++ b/src/Model/WebhookResponseInterface.php
@@ -30,6 +30,13 @@ interface WebhookResponseInterface
     public function getRequest(): WebhookRequestInterface;
 
     /**
+     * Returns the response content.
+     *
+     * @return string|null
+     */
+    public function getResponse(): ?string;
+
+    /**
      * Returns the identifier of the response.
      *
      * @return string

--- a/tests/Stubs/Bridge/Doctrine/Entity/WebhookResponseStub.php
+++ b/tests/Stubs/Bridge/Doctrine/Entity/WebhookResponseStub.php
@@ -71,6 +71,14 @@ class WebhookResponseStub implements WebhookResponseInterface
     /**
      * {@inheritdoc}
      */
+    public function getResponse(): ?string
+    {
+        return $this->data['response'] ?? null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getResponseId(): string
     {
         return '123';

--- a/tests/Unit/Bridge/Doctrine/Entities/WebhookResponseTest.php
+++ b/tests/Unit/Bridge/Doctrine/Entities/WebhookResponseTest.php
@@ -122,6 +122,7 @@ class WebhookResponseTest extends BaseEntityTestCase
                 'request_method' => 'POST',
                 'request_url' => 'https://localhost.com/webhook'
             ],
+            'response' => 'RESPONSE',
             'status_code' => 204,
             'successful' => true
         ];


### PR DESCRIPTION
This PR adds the `getErrorReason` and `getResponse` methods to the WebhookResponse entity to expose the value for use in Subscriptions (see: PYMT-1006).