### PR TITLE
Add webhook-* headers to request object

### DIFF
--- a/src/Activities/ActivityFactory.php
+++ b/src/Activities/ActivityFactory.php
@@ -60,9 +60,6 @@ final class ActivityFactory implements ActivityFactoryInterface
             $payload
         );
 
-        // Add sequence to newly persisted activity's payload.
-        $this->activityPersister->addSequenceToPayload($activityId);
-
         $this->eventDispatcher->dispatchActivityCreated($activityId);
     }
 }

--- a/src/Bridge/Doctrine/Entities/Lifecycle/Request.php
+++ b/src/Bridge/Doctrine/Entities/Lifecycle/Request.php
@@ -83,7 +83,13 @@ class Request extends Entity implements WebhookRequestInterface
      */
     public function getRequestHeaders(): array
     {
-        return $this->requestHeaders;
+        return \array_merge(
+            $this->requestHeaders,
+            [
+                'webhook-activity' => $this->getActivity()->getActivityKey(),
+                'webhook-sequence' => $this->getSequence(),
+            ]
+        );
     }
 
     /**

--- a/src/Bridge/Doctrine/Persisters/ActivityPersister.php
+++ b/src/Bridge/Doctrine/Persisters/ActivityPersister.php
@@ -6,7 +6,6 @@ namespace EoneoPay\Webhooks\Bridge\Doctrine\Persisters;
 use DateTime;
 use EoneoPay\Externals\ORM\Interfaces\EntityInterface;
 use EoneoPay\Webhooks\Bridge\Doctrine\Handlers\Interfaces\ActivityHandlerInterface;
-use EoneoPay\Webhooks\Bridge\Laravel\Exceptions\ActivityNotFoundException;
 use EoneoPay\Webhooks\Models\ActivityInterface;
 use EoneoPay\Webhooks\Persisters\Interfaces\ActivityPersisterInterface;
 
@@ -25,27 +24,6 @@ final class ActivityPersister implements ActivityPersisterInterface
     public function __construct(ActivityHandlerInterface $activityHandler)
     {
         $this->activityHandler = $activityHandler;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function addSequenceToPayload(int $activityId): void
-    {
-        $activity = $this->get($activityId);
-
-        if (($activity instanceof ActivityInterface) !== true) {
-            throw new ActivityNotFoundException(
-                \sprintf('No activity "%s" found to add sequence to payload.', $activityId)
-            );
-        }
-
-        $payload = $activity->getPayload();
-        $activity->setPayload(\array_merge($payload, [
-            '_sequence' => $activityId,
-        ]));
-
-        $this->activityHandler->save($activity);
     }
 
     /**

--- a/src/Persisters/Interfaces/ActivityPersisterInterface.php
+++ b/src/Persisters/Interfaces/ActivityPersisterInterface.php
@@ -10,15 +10,6 @@ use EoneoPay\Webhooks\Models\ActivityInterface;
 interface ActivityPersisterInterface
 {
     /**
-     * Add sequence number to existing activity payload.
-     *
-     * @param int $activityId Activity id.
-     *
-     * @return void
-     */
-    public function addSequenceToPayload(int $activityId): void;
-
-    /**
      * Returns an activity.
      *
      * @param int $activityId

--- a/tests/Stubs/Persisters/ActivityPersisterStub.php
+++ b/tests/Stubs/Persisters/ActivityPersisterStub.php
@@ -38,14 +38,6 @@ class ActivityPersisterStub implements ActivityPersisterInterface
     /**
      * {@inheritdoc}
      */
-    public function addSequenceToPayload(int $activityId): void
-    {
-        $this->addedSequence = $activityId;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function get(int $activityId): ?ActivityInterface
     {
         return $this->nextActivity;

--- a/tests/Unit/Activities/ActivityFactoryTest.php
+++ b/tests/Unit/Activities/ActivityFactoryTest.php
@@ -84,7 +84,6 @@ class ActivityFactoryTest extends TestCase
 
         self::assertSame($expectedActivity, $activityPersister->getSaved());
         self::assertSame($expectedEvent, $dispatcher->getActivityCreated());
-        self::assertSame(5, $activityPersister->getAddedSequence());
     }
 
     /**

--- a/tests/Unit/Bridge/Doctrine/Entities/Lifecycle/RequestTest.php
+++ b/tests/Unit/Bridge/Doctrine/Entities/Lifecycle/RequestTest.php
@@ -28,7 +28,10 @@ class RequestTest extends BaseEntityTestCase
         self::assertSame(123, $request->getId());
         self::assertInstanceOf(Activity::class, $request->getActivity());
         self::assertSame('json', $request->getRequestFormat());
-        self::assertSame(['header' => 'value'], $request->getRequestHeaders());
+        self::assertSame(
+            ['header' => 'value', 'webhook-activity' => 'activity.key', 'webhook-sequence' => 123],
+            $request->getRequestHeaders()
+        );
         self::assertSame('POST', $request->getRequestMethod());
         self::assertSame('https://localhost.com/webhook', $request->getRequestUrl());
         self::assertSame(123, $request->getSequence());
@@ -51,7 +54,10 @@ class RequestTest extends BaseEntityTestCase
         $request->populate($activity, new SubscriptionStub());
 
         self::assertSame('json', $request->getRequestFormat());
-        self::assertSame(['authorization' => 'Bearer ABC123'], $request->getRequestHeaders());
+        self::assertSame(
+            ['authorization' => 'Bearer ABC123', 'webhook-activity' => 'activity.key', 'webhook-sequence' => 123],
+            $request->getRequestHeaders()
+        );
         self::assertSame('POST', $request->getRequestMethod());
         self::assertSame('https://127.0.0.1/webhook', $request->getRequestUrl());
     }
@@ -99,6 +105,8 @@ class RequestTest extends BaseEntityTestCase
             'request_format' => 'json',
             'request_headers' => [
                 'header' => 'value',
+                'webhook-activity' => 'activity.key',
+                'webhook-sequence' => 123,
             ],
             'request_method' => 'POST',
             'request_url' => 'https://localhost.com/webhook',

--- a/tests/Unit/Bridge/Doctrine/Entities/Lifecycle/ResponseTest.php
+++ b/tests/Unit/Bridge/Doctrine/Entities/Lifecycle/ResponseTest.php
@@ -99,6 +99,8 @@ class ResponseTest extends BaseEntityTestCase
                 'request_format' => 'json',
                 'request_headers' => [
                     'header' => 'value',
+                    'webhook-activity' => 'activity.key',
+                    'webhook-sequence' => 123,
                 ],
                 'request_method' => 'POST',
                 'request_url' => 'https://localhost.com/webhook',

--- a/tests/Unit/Bridge/Doctrine/Persisters/ActivityPersisterTest.php
+++ b/tests/Unit/Bridge/Doctrine/Persisters/ActivityPersisterTest.php
@@ -6,7 +6,6 @@ namespace Tests\EoneoPay\Webhooks\Unit\Bridge\Doctrine\Persisters;
 use EoneoPay\Utils\DateTime;
 use EoneoPay\Webhooks\Bridge\Doctrine\Handlers\Interfaces\ActivityHandlerInterface;
 use EoneoPay\Webhooks\Bridge\Doctrine\Persisters\ActivityPersister;
-use EoneoPay\Webhooks\Bridge\Laravel\Exceptions\ActivityNotFoundException;
 use Tests\EoneoPay\Webhooks\Stubs\Bridge\Doctrine\Entities\ActivityStub;
 use Tests\EoneoPay\Webhooks\Stubs\Bridge\Doctrine\Handlers\ActivityHandlerStub;
 use Tests\EoneoPay\Webhooks\Stubs\Externals\EntityStub;
@@ -17,46 +16,6 @@ use Tests\EoneoPay\Webhooks\TestCase;
  */
 class ActivityPersisterTest extends TestCase
 {
-    /**
-     * Test that adding sequence to activity payload returns payload with
-     * activity sequence.
-     *
-     * @return void
-     */
-    public function testAddSequenceToPayload(): void
-    {
-        $activity = new ActivityStub();
-        $activity->setPayload(['key' => 'value']);
-        $activityHandler = new ActivityHandlerStub();
-        $activityHandler->setNext($activity);
-        $expectedPayload = [
-            'key' => 'value',
-            '_sequence' => 5,
-        ];
-        $persister = $this->getPersister($activityHandler);
-
-        $persister->addSequenceToPayload(5);
-
-        self::assertSame($expectedPayload, $activity->getPayload());
-    }
-
-    /**
-     * Test that adding sequence to activity payload throws exception when invalid or
-     * unknown activity id is provided.
-     *
-     * @return void
-     */
-    public function testAddSequenceToPayloadThrowsNotFoundException(): void
-    {
-        $activityHandler = new ActivityHandlerStub();
-        $persister = $this->getPersister($activityHandler);
-
-        $this->expectException(ActivityNotFoundException::class);
-        $this->expectExceptionMessage('No activity "111" found to add sequence to payload.');
-
-        $persister->addSequenceToPayload(111);
-    }
-
     /**
      * Tests get.
      *


### PR DESCRIPTION
Ticket here: https://eonx.atlassian.net/browse/PYMT-1409

This change moves the `_sequence` key from the body to a header and adds in activity key for all requests.